### PR TITLE
feat: shadow styles

### DIFF
--- a/core/BaseComponent.js
+++ b/core/BaseComponent.js
@@ -36,6 +36,13 @@ export class BaseComponent extends HTMLElement {
         fn(fr, this);
       }
     }
+    if (this.constructor['__shadowStylesUrl']) {
+      shadow = true;
+      let styleLink = document.createElement('link');
+      styleLink.rel = 'stylesheet';
+      styleLink.href = this.constructor['__shadowStylesUrl'];
+      fr.prepend(styleLink);
+    }
     if (shadow) {
       if (!this.shadowRoot) {
         this.attachShadow({
@@ -362,5 +369,13 @@ export class BaseComponent extends HTMLElement {
       },
     });
     this[propName] = this[localPropName];
+  }
+
+  /** @param {String} cssTxt */
+  static set shadowStyles(cssTxt) {
+    let styleBlob = new Blob([cssTxt], {
+      type: 'text/css',
+    });
+    this.__shadowStylesUrl = URL.createObjectURL(styleBlob);
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Symbiote.js",
   "author": "hello@symbiotejs.org",
   "license": "MIT",


### PR DESCRIPTION
## CSP compatible Shadow DOM styles (blob: URL) support added

Code example:
```javascript
import { BaseComponent } from '../core/BaseComponent.js';

class ShadowEl extends BaseComponent {
  init$ = {
    txt: 'TEST',
  }
}

ShadowEl.shadowStyles = /*css*/ `
:host {
  color: red;
}
h1 {
  font-style: italic;
}
`;

ShadowEl.template = /*html*/ `
<h1>{{txt}}</h1>
`;

ShadowEl.reg('shadow-el');
```

