### PR TITLE
fix: item init$ merge instead of redefine

### DIFF
--- a/core/repeatProcessor.js
+++ b/core/repeatProcessor.js
@@ -55,7 +55,7 @@ export function repeatProcessor(fr, fnCtx) {
               fragment = new DocumentFragment();
             }
             let repeatItem = new itemClass();
-            repeatItem.init$ = item;
+            Object.assign(repeatItem.init$, item);
             fragment.appendChild(repeatItem);
           }
         });


### PR DESCRIPTION
Needed for the case when item is pre-defined component and already has some defined fields in init$.
