### PR TITLE
Check for primitives in set$ (force arrays, objects, etc)

### DIFF
--- a/core/BaseComponent.js
+++ b/core/BaseComponent.js
@@ -232,12 +232,14 @@ export class BaseComponent extends HTMLElement {
 
   /**
    * @param {Partial<S>} kvObj
-   * @param {Boolean} [force]
+   * @param {Boolean} [forcePrimitives] Force update callbacks for primitive types
    */
-  set$(kvObj, force = false) {
+  set$(kvObj, forcePrimitives = false) {
     for (let key in kvObj) {
       let val = kvObj[key];
-      if (force || val.constructor === Object || val.constructor === Array) {
+      /** @type {unknown[]} */
+      let primArr = [String, Number, Boolean];
+      if (forcePrimitives || !primArr.includes(val.constructor)) {
         this.$[key] = val;
       } else {
         this.$[key] !== val && (this.$[key] = val);

--- a/core/BaseComponent.js
+++ b/core/BaseComponent.js
@@ -236,10 +236,11 @@ export class BaseComponent extends HTMLElement {
    */
   set$(kvObj, force = false) {
     for (let key in kvObj) {
-      if (force) {
-        this.$[key] = kvObj[key];
+      let val = kvObj[key];
+      if (force || val.constructor === Object || val.constructor === Array) {
+        this.$[key] = val;
       } else {
-        this.$[key] !== kvObj[key] && (this.$[key] = kvObj[key]);
+        this.$[key] !== val && (this.$[key] = val);
       }
     }
   }


### PR DESCRIPTION
Primitives could be binded into the templates directly, so it's better to skip them for update callbacks by default, but other types - are not. 

Example case: we trying to use dynamic list rendering for the nested list (list inside  the parent list item).

_For the future discussions: is it useful to check for `BigInt` & `Symbol`?_
