### PR TITLE
fix: nested props bindings

### DIFF
--- a/core/BaseComponent.js
+++ b/core/BaseComponent.js
@@ -1,6 +1,7 @@
 import { Data } from './Data.js';
 import { DICT } from './dictionary.js';
 import { UID } from '../utils/UID.js';
+import { setNestedProp } from '../utils/setNestedProp.js';
 
 import PROCESSORS from './tpl-processors.js';
 
@@ -301,6 +302,12 @@ export class BaseComponent extends HTMLElement {
         this.style.setProperty(DICT.CSS_CTX_PROP, `'${ctxNameAttrVal}'`);
       }
       this.__initDataCtx();
+      if (this[DICT.SET_LATER_KEY]) {
+        for (let prop in this[DICT.SET_LATER_KEY]) {
+          setNestedProp(this, prop, this[DICT.SET_LATER_KEY][prop]);
+        }
+        delete this[DICT.SET_LATER_KEY];
+      }
       this.initChildren = [...this.childNodes];
       for (let proc of PROCESSORS) {
         this.addTemplateProcessor(proc);

--- a/core/dictionary.js
+++ b/core/dictionary.js
@@ -20,4 +20,6 @@ export const DICT = Object.freeze({
   REPEAT_ATTR: 'repeat',
   // List item tag name:
   REPEAT_ITEM_TAG_ATTR: 'repeat-item-tag',
+  // Key to restore nested properties was set before component construction
+  SET_LATER_KEY: '__toSetLater__',
 });

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "1.8.4",
+  "version": "1.8.5",
   "description": "Symbiote.js",
   "author": "hello@symbiotejs.org",
   "license": "MIT",

--- a/utils/setNestedProp.js
+++ b/utils/setNestedProp.js
@@ -1,0 +1,24 @@
+/**
+ * @param {any} parent
+ * @param {String} path
+ * @param {any} value
+ */
+export function setNestedProp(parent, path, value) {
+  let success = true;
+  /** @type {String} */
+  let lastStep;
+  let propPath = path.split('.');
+  propPath.forEach((step, idx) => {
+    if (idx < propPath.length - 1) {
+      parent = parent[step];
+    } else {
+      lastStep = step;
+    }
+  });
+  if (parent) {
+    parent[lastStep] = value;
+  } else {
+    success = false;
+  }
+  return success;
+}


### PR DESCRIPTION
## nested props bindings

The issue was related to the custom elements construction flow, where was a moment when something tries to set some property to the component but it wasn't properly constructed yet.

- setNestedProperty utility function was added
- basic template processor was fixed
- component now able to restore nested properties was set before initialization
