### PR TITLE
fix: *prop binding race

### DIFF
--- a/core/BaseComponent.js
+++ b/core/BaseComponent.js
@@ -187,7 +187,15 @@ export class BaseComponent extends HTMLElement {
    */
   sub(prop, handler) {
     let parsed = BaseComponent.__parseProp(/** @type {string} */ (prop), this);
-    this.allSubs.add(parsed.ctx.sub(parsed.name, handler));
+    // @ts-ignore
+    if (!parsed.ctx.has(prop)) {
+      // Avoid *prop binding race:
+      window.setTimeout(() => {
+        this.allSubs.add(parsed.ctx.sub(parsed.name, handler));
+      });
+    } else {
+      this.allSubs.add(parsed.ctx.sub(parsed.name, handler));
+    }
   }
 
   /** @param {String} prop */

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "1.8.6",
+  "version": "1.8.7",
   "description": "Symbiote.js",
   "author": "hello@symbiotejs.org",
   "license": "MIT",


### PR DESCRIPTION
Issue reproducing case:
```js
import { BaseComponent } from '../../core/BaseComponent.js';

class InnerEl extends BaseComponent {
  init$ = {
    '*innerProp': 'inner value',
  }
}

InnerEl.template = /*html*/ `
<div>{{*outerProp}}</div>
`;
InnerEl.reg('inner-el');

/// Wrapper:
class TestApp extends BaseComponent {
  init$ = {
    '*outerProp': 'outer value',
  }
}

TestApp.template = /*html*/ `
<div>{{*innerProp}}</div>
<inner-el></inner-el>
`;
TestApp.reg('test-app');
```
