### PR TITLE
Bindings from dedicated attributes

### DIFF
--- a/core/symbiote.js
+++ b/core/symbiote.js
@@ -12,3 +12,4 @@ export { applyStyles } from '../utils/dom-helpers.js';
 export { applyAttributes } from '../utils/dom-helpers.js';
 export { create } from '../utils/dom-helpers.js';
 export { IDB } from '../utils/IDB.js';
+export { kebabToCamel } from '../utils/kebabToCamel.js';

--- a/core/tpl-processors.js
+++ b/core/tpl-processors.js
@@ -1,5 +1,6 @@
 import { DICT } from './dictionary.js';
 import { setNestedProp } from '../utils/setNestedProp.js';
+import { kebabToCamel } from '../utils/kebabToCamel.js';
 // Should go first among other processors:
 import { repeatProcessor } from './repeatProcessor.js';
 
@@ -67,6 +68,13 @@ function domSetProcessor(fr, fnCtx) {
   [...fr.querySelectorAll(`[${DICT.BIND_ATTR}]`)].forEach((el) => {
     let subStr = el.getAttribute(DICT.BIND_ATTR);
     let keyValArr = subStr.split(';');
+    [...el.attributes].forEach((attr) => {
+      if (attr.name.startsWith('-') && attr.value) {
+        let key = kebabToCamel(attr.name.replace('-', ''));
+        keyValArr.push(key + ':' + attr.value);
+        el.removeAttribute(attr.name);
+      }
+    });
     keyValArr.forEach((keyValStr) => {
       if (!keyValStr) {
         return;

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "1.8.7",
+  "version": "1.9.0",
   "description": "Symbiote.js",
   "author": "hello@symbiotejs.org",
   "license": "MIT",

--- a/utils/kebabToCamel.js
+++ b/utils/kebabToCamel.js
@@ -1,0 +1,14 @@
+/** @param {String} string */
+export function kebabToCamel(string) {
+  return string
+    .split('-')
+    .map((p, i) => {
+      return p && i ? p[0].toUpperCase() + p.slice(1) : p;
+    })
+    .join('')
+    .split('_')
+    .map((p, i) => {
+      return p && i ? p.toUpperCase() : p;
+    })
+    .join('');
+}


### PR DESCRIPTION
New syntax example:
```js
import { BaseComponent } from '../../core/BaseComponent.js';

class MyApp extends BaseComponent {

  init$= {
    text: 'TEXT',
    cssColor: '#f00',
    cssBgColor: '#ff0',
    html: /*html*/ `<h2>TEST</h2>`,
    click: () => {
      console.log(this);
    },
  }

}

MyApp.template = /*html*/ `
<div set 
  -onclick="click"
  -inner_html="html"
  -style.background-color="cssBgColor"
  -style.color="cssColor"></div>
<div set -text-content="text"></div>
`;
MyApp.reg('my-app');
```

