### PR TITLE
Custom template

### DIFF
--- a/core/BaseComponent.js
+++ b/core/BaseComponent.js
@@ -46,6 +46,21 @@ export class BaseComponent extends HTMLElement {
         mode: 'open',
       });
     }
+    if (this.allowCustomTemplate) {
+      let customTplSelector = this.getAttribute(DICT.USE_TPL);
+      if (customTplSelector) {
+        let root = this.getRootNode();
+        /** @type {HTMLTemplateElement} */
+        // @ts-ignore
+        let customTpl = root?.querySelector(customTplSelector) || document.querySelector(customTplSelector);
+        if (customTpl) {
+          // @ts-ignore
+          template = customTpl.content.cloneNode(true);
+        } else {
+          console.warn(`Symbiote template "${customTplSelector}" is not found...`);
+        }
+      }
+    }
     if (this.processInnerHtml) {
       for (let fn of this.tplProcessors) {
         fn(this, this);
@@ -116,6 +131,8 @@ export class BaseComponent extends HTMLElement {
     this.readyToDestroy = true;
     /** @type {Boolean} */
     this.processInnerHtml = false;
+    /** @type {Boolean} */
+    this.allowCustomTemplate = false;
   }
 
   /** @returns {String} */

--- a/core/dictionary.js
+++ b/core/dictionary.js
@@ -22,4 +22,6 @@ export const DICT = Object.freeze({
   REPEAT_ITEM_TAG_ATTR: 'repeat-item-tag',
   // Key to restore nested properties was set before component construction
   SET_LATER_KEY: '__toSetLater__',
+  // Attribute to provide selector of custom template
+  USE_TPL: 'use-template',
 });

--- a/core/tpl-processors.js
+++ b/core/tpl-processors.js
@@ -172,6 +172,7 @@ const txtNodesProcessor = function (fr, fnCtx) {
     }
     tokenNodes.forEach((tNode) => {
       let prop = tNode.textContent.replace(OPEN_TOKEN, '').replace(CLOSE_TOKEN, '');
+      tNode.textContent = '';
       fnCtx.sub(prop, (val) => {
         tNode.textContent = val;
       });


### PR DESCRIPTION
## Custom templates support

Usage example:
```html
<template id="tpl">
  <h1 set -text-content="heading"></h1>
  <button set -onclick="click">CLICK ME</button>
</template>

<ctx-el use-template="#tpl"></ctx-el>
```
Component definition:
```js
class CtxEl extends BaseComponent {
  allowCustomTemplate = true;

  init$ = {
    heading: 'Hello!',
    click: () => {
      console.log('Click!');
    },
  };

}

CtxEl.reg('ctx-el');
```
