### PR TITLE
feat: root styles support

### DIFF
--- a/core/BaseComponent.js
+++ b/core/BaseComponent.js
@@ -388,7 +388,7 @@ export class BaseComponent extends HTMLElement {
             this.render();
           };
           // @ts-ignore
-          root.nodeType === 9 ? root.head.appendChild(rootLink) : root.prepend(rootLink);
+          root.nodeType === Node.DOCUMENT_NODE ? root.head.appendChild(rootLink) : root.prepend(rootLink);
         } else {
           this.render();
         }

--- a/core/dictionary.js
+++ b/core/dictionary.js
@@ -26,4 +26,6 @@ export const DICT = Object.freeze({
   SET_LATER_KEY: '__toSetLater__',
   // Attribute to provide selector of custom template
   USE_TPL: 'use-template',
+  // Root style attribute name:
+  ROOT_STYLE_ATTR_NAME: 'sym-component',
 });


### PR DESCRIPTION
## Component styles for the external root styling scope

Usage example:
```js
import { BaseComponent } from '../../core/BaseComponent.js';

class TestApp extends BaseComponent {
  init$ = {
    text: 'MY TEXT',
  }
}

TestApp.rootStyles = /*css*/ `
test-app {
  color: #f00;
}
`;

// Could be mixed with shadow styles if needed:
TestApp.shadowStyles = /*css*/ `
:host {
  font-size: 2em;
}
`;

TestApp.template = /*html*/ `
<div>{{text}}</div>
`;

TestApp.reg('test-app');
```
