### PR TITLE
fix: clear local sate on destroy

### DIFF
--- a/core/PubSub.js
+++ b/core/PubSub.js
@@ -16,7 +16,10 @@ function cloneObj(obj) {
 /** @template {Record<string, unknown>} T */
 export class PubSub {
 
+  /** @type {String | Symbol} */
+  #uid;
   #proxy;
+  /** @type {Boolean} */
   #storeIsProxy;
 
   /** @param {T} schema */
@@ -183,6 +186,17 @@ export class PubSub {
     };
   }
 
+  /** 
+   * @param {String | Symbol} uid 
+   */
+  set uid(uid) {
+    !this.#uid && (this.#uid = uid);
+  }
+
+  get uid() {
+    return this.#uid;
+  }
+
   /**
    * @template {Record<string, unknown>} S
    * @param {S} schema
@@ -196,6 +210,7 @@ export class PubSub {
       console.warn('PubSub: context UID "' + uid + '" is already in use');
     } else {
       data = new PubSub(schema);
+      data.uid = uid;
       PubSub.globalStore.set(uid, data);
     }
     return data;

--- a/core/Symbiote.js
+++ b/core/Symbiote.js
@@ -447,6 +447,7 @@ export class Symbiote extends HTMLElement {
         sub.remove();
         this.allSubs.delete(sub);
       }
+      this.#localCtx && PubSub.deleteCtx(this.#localCtx.uid);
       for (let proc of this.tplProcessors) {
         this.tplProcessors.delete(proc);
       }

--- a/types/symbiote.d.ts
+++ b/types/symbiote.d.ts
@@ -44,6 +44,8 @@ declare module "core/PubSub" {
             remove: () => void;
             callback: (val: unknown) => void;
         };
+        set uid(arg: string | Symbol);
+        get uid(): string | Symbol;
         #private;
     }
     export namespace PubSub {


### PR DESCRIPTION
This changes are preventing memory leaks:

1. `uid` getter is added to PubSub instances.
2. localCtx is now deleting on destruction lifecycle stage
